### PR TITLE
Bring package name inline with npm standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Mixd-Frontend-Framework",
+  "name": "mixd-frontend-framework",
   "version": "1.4.0",
   "devDependencies": {
     "autoprefixer": "~6.3.3",


### PR DESCRIPTION
NPM Package.json standards dictate that the [package name should be lowercase](https://docs.npmjs.com/files/package.json#name)